### PR TITLE
Fix: scrollview automatically scrolls to ad on Android devices

### DIFF
--- a/android/src/ti/dfp/View.java
+++ b/android/src/ti/dfp/View.java
@@ -10,6 +10,8 @@ import android.location.Location;
 import java.util.Map;
 import java.util.HashMap;
 
+import android.view.ViewGroup;
+
 import com.google.android.gms.ads.AdListener;
 import com.google.android.gms.ads.doubleclick.PublisherAdRequest;
 import com.google.android.gms.ads.AdSize;
@@ -43,6 +45,7 @@ public class View extends TiUIView {
 		    Log.d (TAG, "[ti.dfp] createView()");
             // create the adView
             adView = new PublisherAdView(proxy.getActivity());
+            adView.setDescendantFocusability(ViewGroup.FOCUS_BLOCK_DESCENDANTS);
 
             if(DfpModule.AD_SIZES != null)
             {


### PR DESCRIPTION
When an ad view was placed at the bottom of a scrollview, the ad would take focus and cause the scrollview to automatically scroll to the ad. 